### PR TITLE
manager create duplicate tags if name contains accented character

### DIFF
--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -170,8 +170,19 @@ class _TaggableManager(models.Manager):
             name__in=str_tags
         )
         tag_objs.update(existing)
-
-        for new_tag in str_tags - set(t.name for t in existing):
+        
+        
+        existing = set(t.name.lower() for t in existing)
+        tags_to_create = [ tag for tag in str_tags if tag.lower() not in existing]
+        
+        _created = []
+        #for new_tag in str_tags - set(t.name for t in existing):
+        for new_tag in tags_to_create:
+            
+            if new_tag.lower() in _created:
+                continue
+            
+            _created.append(new_tag.lower() )
             tag_objs.add(self.through.tag_model().objects.create(name=new_tag))
 
         for tag in tag_objs:

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -157,6 +157,7 @@ class _TaggableManager(models.Manager):
 
     @require_instance_manager
     def add(self, *tags):
+        tags = [ force_unicode(t) if not isinstance(t, self.through.tag_model()) else t for t in tags ]
         str_tags = set([
             t
             for t in tags

--- a/taggit/managers.py
+++ b/taggit/managers.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 from taggit.forms import TagField
 from taggit.models import TaggedItem, GenericTaggedItemBase
 from taggit.utils import require_instance_manager
-
+from django.utils.encoding import force_unicode
 
 try:
     all


### PR DESCRIPTION
forcing tag string to unicode fix the bug
