### PR TITLE
Fixing database exceptions

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -40,7 +40,7 @@ class TagBase(models.Model):
                     res = super(TagBase, self).save(*args, **kwargs)
                     transaction.savepoint_commit(sid, **trans_kwargs)
                     return res
-                except (utils.IntegrityError, utils.DatabaseError):
+                except utils.IntegrityError:
                     transaction.savepoint_rollback(sid, **trans_kwargs)
                     self.slug = self.slugify(self.name, i)
         else:

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -5,12 +5,7 @@ from django.db import models, transaction
 from django.db.models.query import QuerySet
 from django.template.defaultfilters import slugify as default_slugify
 from django.utils.translation import ugettext_lazy as _, ugettext
-try:
-    from psycopg2 import InternalError
-    DBError = InternalError
-except ImportError:
-    from django.db import IntegrityError
-    DBError = IntegrityError
+from django.db import utils
 
 
 class TagBase(models.Model):
@@ -45,7 +40,7 @@ class TagBase(models.Model):
                     res = super(TagBase, self).save(*args, **kwargs)
                     transaction.savepoint_commit(sid, **trans_kwargs)
                     return res
-                except DBError:
+                except (utils.IntegrityError, utils.DatabaseError):
                     transaction.savepoint_rollback(sid, **trans_kwargs)
                     self.slug = self.slugify(self.name, i)
         else:


### PR DESCRIPTION
All Django database backends capture the adapter exceptions and re-raise
them as `django.db.utils` exceptions, so it's safe and agnostic to just
capture these.
